### PR TITLE
feat: setup Terraform remote backend and fix Learner Lab IAM roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+.terraform.lock.hcl
+tfplan

--- a/bootstrap-remote-state.sh
+++ b/bootstrap-remote-state.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUCKET_NAME="cs365-tf-state-bucket"
+DYNAMODB_TABLE="cs365-tf-lock"
+REGION="us-east-1"
+
+echo "==> Creating S3 bucket: $BUCKET_NAME"
+aws s3api create-bucket \
+  --bucket "$BUCKET_NAME" \
+  --region "$REGION"
+
+echo "==> Enabling versioning on S3 bucket"
+aws s3api put-bucket-versioning \
+  --bucket "$BUCKET_NAME" \
+  --versioning-configuration Status=Enabled
+
+echo "==> Enabling server-side encryption on S3 bucket"
+aws s3api put-bucket-encryption \
+  --bucket "$BUCKET_NAME" \
+  --server-side-encryption-configuration '{
+    "Rules": [{
+      "ApplyServerSideEncryptionByDefault": {
+        "SSEAlgorithm": "AES256"
+      }
+    }]
+  }'
+
+echo "==> Blocking public access on S3 bucket"
+aws s3api put-public-access-block \
+  --bucket "$BUCKET_NAME" \
+  --public-access-block-configuration \
+    "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
+
+echo "==> Creating DynamoDB table: $DYNAMODB_TABLE"
+aws dynamodb create-table \
+  --table-name "$DYNAMODB_TABLE" \
+  --attribute-definitions AttributeName=LockID,AttributeType=S \
+  --key-schema AttributeName=LockID,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST \
+  --region "$REGION"
+
+echo "==> Waiting for DynamoDB table to become active..."
+aws dynamodb wait table-exists \
+  --table-name "$DYNAMODB_TABLE" \
+  --region "$REGION"
+
+echo ""
+echo "Done! Remote state backend is ready."
+echo "  S3 bucket : $BUCKET_NAME"
+echo "  DynamoDB  : $DYNAMODB_TABLE"
+echo ""
+echo "Next: cd terraform/eks && terraform init"

--- a/terraform/modules/eks/main.tf
+++ b/terraform/modules/eks/main.tf
@@ -1,10 +1,19 @@
 # Use pre-existing LabEksClusterRole (Learner Lab restriction: cannot create IAM roles)
+# Role names in Learner Lab have a generated prefix, so we look them up by path/tag filter
+data "aws_iam_roles" "cluster" {
+  name_regex = ".*LabEksClusterRole.*"
+}
+
+data "aws_iam_roles" "nodes" {
+  name_regex = ".*LabEksNodeRole.*"
+}
+
 data "aws_iam_role" "cluster" {
-  name = "LabEksClusterRole"
+  name = tolist(data.aws_iam_roles.cluster.names)[0]
 }
 
 data "aws_iam_role" "nodes" {
-  name = "LabEksNodeRole"
+  name = tolist(data.aws_iam_roles.nodes.names)[0]
 }
 
 resource "aws_eks_cluster" "main" {
@@ -47,13 +56,4 @@ resource "aws_eks_node_group" "main" {
   }
 }
 
-# OIDC Provider for IRSA (IAM Roles for Service Accounts)
-data "tls_certificate" "eks" {
-  url = aws_eks_cluster.main.identity[0].oidc[0].issuer
-}
-
-resource "aws_iam_openid_connect_provider" "eks" {
-  client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = [data.tls_certificate.eks.certificates[0].sha1_fingerprint]
-  url             = aws_eks_cluster.main.identity[0].oidc[0].issuer
-}
+# OIDC Provider removed — Learner Lab does not allow iam:CreateOpenIDConnectProvider

--- a/terraform/modules/eks/outputs.tf
+++ b/terraform/modules/eks/outputs.tf
@@ -10,10 +10,3 @@ output "cluster_certificate_authority_data" {
   value = aws_eks_cluster.main.certificate_authority[0].data
 }
 
-output "oidc_provider_arn" {
-  value = aws_iam_openid_connect_provider.eks.arn
-}
-
-output "oidc_provider_url" {
-  value = aws_iam_openid_connect_provider.eks.url
-}


### PR DESCRIPTION
- Add bootstrap-remote-state.sh to create S3 bucket + DynamoDB table
- Add .gitignore for Terraform artifacts
- Fix EKS module to look up LabEksClusterRole/LabEksNodeRole by regex (Learner Lab prefixes role names with a generated string)
- Remove OIDC provider resource (not permitted in Learner Lab)