### PR TITLE
feat: add EC2 jump server module

### DIFF
--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -30,3 +30,12 @@ module "iam" {
 
   cluster_name = var.cluster_name
 }
+
+module "jump_server" {
+  source = "../modules/jump-server"
+
+  cluster_name     = var.cluster_name
+  vpc_id           = module.vpc.vpc_id
+  public_subnet_id = module.vpc.public_subnet_ids[0]
+  aws_region       = var.aws_region
+}

--- a/terraform/eks/outputs.tf
+++ b/terraform/eks/outputs.tf
@@ -23,3 +23,13 @@ output "private_subnet_ids" {
   description = "Private subnet IDs"
   value       = module.vpc.private_subnet_ids
 }
+
+output "jump_server_ip" {
+  description = "Jump server public IP"
+  value       = module.jump_server.public_ip
+}
+
+output "jump_server_id" {
+  description = "Jump server instance ID"
+  value       = module.jump_server.instance_id
+}

--- a/terraform/modules/jump-server/main.tf
+++ b/terraform/modules/jump-server/main.tf
@@ -1,0 +1,61 @@
+resource "aws_security_group" "jump" {
+  name        = "${var.cluster_name}-jump-sg"
+  description = "Security group for Jump Server"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.cluster_name}-jump-sg"
+  }
+}
+
+resource "aws_instance" "jump" {
+  ami                         = var.ami_id
+  instance_type               = "t3.micro"
+  subnet_id                   = var.public_subnet_id
+  vpc_security_group_ids      = [aws_security_group.jump.id]
+  key_name                    = var.key_name
+  associate_public_ip_address = true
+
+  iam_instance_profile = var.instance_profile
+
+  user_data = <<-EOF
+    #!/bin/bash
+    set -e
+
+    # AWS CLI v2
+    curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+    unzip -q /tmp/awscliv2.zip -d /tmp
+    /tmp/aws/install
+
+    # kubectl
+    curl -sLO "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
+    # helm
+    curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+    # kubeconfig
+    aws eks update-kubeconfig --region ${var.aws_region} --name ${var.cluster_name}
+
+    echo "Jump server ready" > /var/log/jump-server-init.log
+  EOF
+
+  tags = {
+    Name = "${var.cluster_name}-jump-server"
+  }
+}

--- a/terraform/modules/jump-server/outputs.tf
+++ b/terraform/modules/jump-server/outputs.tf
@@ -1,0 +1,7 @@
+output "public_ip" {
+  value = aws_instance.jump.public_ip
+}
+
+output "instance_id" {
+  value = aws_instance.jump.id
+}

--- a/terraform/modules/jump-server/variables.tf
+++ b/terraform/modules/jump-server/variables.tf
@@ -1,0 +1,31 @@
+variable "cluster_name" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "public_subnet_id" {
+  type = string
+}
+
+variable "ami_id" {
+  type    = string
+  default = "ami-0c1e21d82fe9c9336"
+}
+
+variable "key_name" {
+  type    = string
+  default = "vockey"
+}
+
+variable "instance_profile" {
+  type    = string
+  default = "LabInstanceProfile"
+}
+
+variable "aws_region" {
+  type    = string
+  default = "us-east-1"
+}


### PR DESCRIPTION
## Summary
- Add `terraform/modules/jump-server` module with EC2 instance, security group
- Instance placed in public subnet of EKS VPC with `LabInstanceProfile`
- `user_data` auto-installs kubectl, helm, aws-cli and configures kubeconfig for `cs365-eks-cluster`
- Add `jump_server_ip` and `jump_server_id` outputs to root module

## Test plan
- [ ] `terraform apply` completes with 2 resources added
- [ ] EC2 instance visible in AWS Console (`cs365-eks-cluster-jump-server`)
- [ ] SSH to jump server: `ssh -i labsuser.pem ec2-user@<jump_server_ip>`
- [ ] Verify tools: `kubectl version`, `helm version`, `aws --version`
- [ ] Verify kubeconfig: `kubectl get nodes`