### PR TITLE
fix: improve security and infrastructure best practices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,14 @@
 *.tfstate.backup
 .terraform.lock.hcl
 tfplan
+
+# SSH Keys & Secrets
+*.pem
+*.key
+*.p12
+*.pfx
+.env
+.env.*
+
+# OS
+.DS_Store

--- a/charts/templates/ingress.yaml
+++ b/charts/templates/ingress.yaml
@@ -8,6 +8,12 @@ metadata:
     {{- toYaml .Values.ingress.annotations | nindent 4 }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
+  {{- if and .Values.ingress.tls.enabled .Values.ingress.tls.secretName }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
   rules:
     - {{- if .Values.ingress.host }}host: {{ .Values.ingress.host }}{{ end }}
       http:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -20,6 +20,10 @@ ingress:
   host: ""
   path: /
   pathType: Prefix
+  tls:
+    enabled: false
+    # Set to true and provide secretName when cert-manager is configured
+    secretName: ""
 
 resources:
   requests:

--- a/terraform/eks/dev.tfvars
+++ b/terraform/eks/dev.tfvars
@@ -11,3 +11,7 @@ max_capacity       = 3
 
 is_eks_role_enabled          = true
 is_eks_nodegroup_role_enabled = true
+
+# Restrict SSH access to jump server — replace with your team's actual IP(s)
+# e.g. ssh_allowed_cidrs = ["203.0.113.10/32", "198.51.100.0/24"]
+ssh_allowed_cidrs = ["0.0.0.0/0"]

--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -34,8 +34,11 @@ module "iam" {
 module "jump_server" {
   source = "../modules/jump-server"
 
-  cluster_name     = var.cluster_name
-  vpc_id           = module.vpc.vpc_id
-  public_subnet_id = module.vpc.public_subnet_ids[0]
-  aws_region       = var.aws_region
+  cluster_name      = var.cluster_name
+  vpc_id            = module.vpc.vpc_id
+  public_subnet_id  = module.vpc.public_subnet_ids[0]
+  aws_region        = var.aws_region
+  ssh_allowed_cidrs = var.ssh_allowed_cidrs
+
+  depends_on = [module.eks]
 }

--- a/terraform/eks/variables.tf
+++ b/terraform/eks/variables.tf
@@ -68,3 +68,9 @@ variable "is_eks_nodegroup_role_enabled" {
   type        = bool
   default     = true
 }
+
+variable "ssh_allowed_cidrs" {
+  description = "CIDR blocks allowed to SSH into the jump server"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}

--- a/terraform/modules/jump-server/main.tf
+++ b/terraform/modules/jump-server/main.tf
@@ -1,14 +1,30 @@
+# Amazon Linux 2023 — latest AMI in the given region
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
 resource "aws_security_group" "jump" {
   name        = "${var.cluster_name}-jump-sg"
   description = "Security group for Jump Server"
   vpc_id      = var.vpc_id
 
   ingress {
-    description = "SSH"
+    description = "SSH from allowed CIDRs only"
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.ssh_allowed_cidrs
   }
 
   egress {
@@ -24,7 +40,7 @@ resource "aws_security_group" "jump" {
 }
 
 resource "aws_instance" "jump" {
-  ami                         = var.ami_id
+  ami                         = data.aws_ami.amazon_linux.id
   instance_type               = "t3.micro"
   subnet_id                   = var.public_subnet_id
   vpc_security_group_ids      = [aws_security_group.jump.id]

--- a/terraform/modules/jump-server/variables.tf
+++ b/terraform/modules/jump-server/variables.tf
@@ -1,31 +1,39 @@
 variable "cluster_name" {
-  type = string
+  description = "EKS cluster name"
+  type        = string
 }
 
 variable "vpc_id" {
-  type = string
+  description = "VPC ID to place the jump server in"
+  type        = string
 }
 
 variable "public_subnet_id" {
-  type = string
+  description = "Public subnet ID for the jump server"
+  type        = string
 }
 
-variable "ami_id" {
-  type    = string
-  default = "ami-0c1e21d82fe9c9336"
+variable "ssh_allowed_cidrs" {
+  description = "List of CIDR blocks allowed to SSH into the jump server"
+  type        = list(string)
+  # Override in dev.tfvars — do not leave as 0.0.0.0/0 in production
+  default = ["0.0.0.0/0"]
 }
 
 variable "key_name" {
-  type    = string
-  default = "vockey"
+  description = "EC2 key pair name"
+  type        = string
+  default     = "vockey"
 }
 
 variable "instance_profile" {
-  type    = string
-  default = "LabInstanceProfile"
+  description = "IAM instance profile for the jump server"
+  type        = string
+  default     = "LabInstanceProfile"
 }
 
 variable "aws_region" {
-  type    = string
-  default = "us-east-1"
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
 }


### PR DESCRIPTION
## Summary
- Add `*.pem`, `*.key`, `.env*`, `.DS_Store` to `.gitignore` to prevent secrets from being committed
- Replace hardcoded AMI ID with `data.aws_ami` dynamic lookup (Amazon Linux 2023)
- Restrict jump server SSH access via configurable `ssh_allowed_cidrs` variable (set your team's IP in `dev.tfvars`)
- Add `depends_on = [module.eks]` to `jump_server` module to prevent race condition on first apply
- Add TLS support to Helm ingress template (disabled by default, enable when cert-manager is ready)

## Test plan
- [ ] Run `terraform fmt -check -recursive` in `terraform/eks/`
- [ ] Run `terraform validate` after `terraform init`
- [ ] Update `ssh_allowed_cidrs` in `dev.tfvars` to actual team IPs before applying
- [ ] Confirm `labsuser.pem` is no longer tracked by git after merge